### PR TITLE
add query_range, query_scheduler and custom configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a fork of a simple and extremely useful diogenxs.loki role.
 Requirements
 ------------
 
-- Ansible >=  2.9
+- Ansible >= 3.0
 
 Example Playbook
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,11 @@ loki_table_manager_config:
   retention_deletes_enabled: false
   retention_period: 0s
 loki_ruler_config: {}
+loki_query_scheduler: {}
+loki_query_range: {}
+
+# catch-all config option to be added "verbatim" to loki.yml
+loki_custom_config: {}
 
 promtail_client_config:
   - url: "http://{{ loki_listen_address }}:{{ loki_listen_port }}/loki/api/v1/push"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Deploy and configure Loki and Promtail.
   issue_tracker_url: https://github.com/weakcamel/ansible-role-loki/issues
   license: WTFPL
-  min_ansible_version: "2.9"
+  min_ansible_version: "3.0"
   platforms:
     - name: Ubuntu
       versions:

--- a/templates/loki.yml.j2
+++ b/templates/loki.yml.j2
@@ -61,3 +61,14 @@ runtime_config:
 ruler:
   {{ loki_ruler_config | to_nice_yaml(indent=2) | indent(2, False) }}
 {% endif %}
+{% if loki_query_scheduler %}
+query_scheduler:
+  {{ loki_query_scheduler | to_nice_yaml(indent=2) | indent(2, False) }}
+{% endif %}
+{% if loki_query_range %}
+query_range:
+  {{ loki_query_range | to_nice_yaml(indent=2) | indent(2, False) }}
+{% endif %}
+{% if loki_custom_config %}
+{{ loki_custom_config | to_nice_yaml(indent=2) }}
+{% endif %}


### PR DESCRIPTION
* added new loki config keys:
  * query_range and query_scheduler for the sake of https://github.com/grafana/loki/issues/4613
  * custom_config is for all future sections which may be added and aren't available at the moment of publishing this role
* formatting fixes (yamllint findings)