### PR TITLE
replace include with import_tasks

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,7 @@
 galaxy_info:
   author: Waldek Maleska
   role_name: loki
+  namespace: weakcamel
   description: Deploy and configure Loki and Promtail.
   issue_tracker_url: https://github.com/weakcamel/ansible-role-loki/issues
   license: WTFPL

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,17 @@
 ---
-- include: preflight.yml
+- name: Pre-flight tasks
+  import_tasks: preflight.yml
   tags:
     - loki_pre_install
 
-- include: install.yml
+- name: Installation tasks
+  import_tasks: install.yml
   become: true
   tags:
     - loki_configure
 
-- include: configure.yml
+- name: Configuration tasks
+  import_tasks: configure.yml
   become: true
   tags:
     - loki_configure


### PR DESCRIPTION
Bare `include` is being deprecated hence swapping it with an equivalent.