### PR TITLE
fix: added missing dependency

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,6 +37,10 @@
   with_items:
     - "{{ loki_config_dir }}"
 
+- name: Ensuring the unzip package is installed
+  ansible.builtin.package:
+    name: unzip
+
 - name: Retrieve Loki binaries
   block:
     - name: Download binaries to a temporary folder


### PR DESCRIPTION
The current playbook fails if the `unzip` command is not present because of the [unpack binaries](https://github.com/weakcamel/ansible-role-loki/blob/master/tasks/install.yml#L59) task using unarchive to decompress a .zip file.